### PR TITLE
Handle descriptor access through Model class

### DIFF
--- a/django_deprecate_fields/deprecate_field.py
+++ b/django_deprecate_fields/deprecate_field.py
@@ -30,6 +30,8 @@ class DeprecatedField(object):
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
         logger.warning(msg)
+        if obj is None:
+            return self
         if not callable(self.val):
             return self.val
         return self.val()

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,0 +1,7 @@
+exceptiongroup==1.1.3
+iniconfig==2.0.0
+packaging==23.2
+pluggy==1.3.0
+pytest==7.4.2
+pytest-django==4.5.2
+tomli==2.0.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import django
+import pytest
+from django.conf import settings
+
+
+@pytest.fixture(autouse=True)
+def enable_db_access_for_all_tests(db):
+    pass
+
+
+def pytest_configure(config):
+    settings.configure(
+        INSTALLED_APPS=["tests"],
+        DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3"}},
+    )
+    django.setup()

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,6 @@
+from django_deprecate_fields import deprecate_field
+from django.db import models
+
+
+class DeprecationModel(models.Model):
+    foo = deprecate_field(models.IntegerField())

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,21 @@
+import pytest
+
+from django_deprecate_fields.deprecate_field import DeprecatedField
+from tests.models import DeprecationModel
+
+
+class TestCore:
+    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
+    def test_descriptor_access(self):
+        """
+        Test that accessing a descriptor through Model class works.
+
+        When accessing a descriptor through a Model instance (i.e. a concrete
+        record), the result should be whatever logic the descriptor is set up
+        to execute.
+
+        When accessing a descriptor through a Model class, the result should be
+        the descriptor itself as there is no object on which to act.
+        """
+        assert DeprecationModel().foo is None
+        assert isinstance(DeprecationModel.foo, DeprecatedField)


### PR DESCRIPTION
This commit makes necessary changes to the DeprecatedField descriptor so that it behaves as expected when accessed without a Model instance.

The expected behavior when accessed through a Model instance is to return the value computed / stored by the descriptor.

The expected behavior when accessed through a Model class is to return the descriptor itself.

This commit also introduces a first test and the necessary libraries and requirements files to setup said test.