### PR TITLE
Allow the usage of model instance for callable return_instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,102 @@ class MyModel(models.Model):
 
 Secondly, `makemigrations` should be called, which will change the field to be nullable. Any lingering references to it
 in your code will return `None` (or optionally any value or callable passed to `deprecate_field` as the
-`return_instead` argument)
+`return_instead` argument, see below for more info).
 
 Lastly, after the changes above have been deployed, `field1` can then safely be removed in the model (plus another
 `makemigrations` run)
+
+## Modifying the returned value
+
+`deprecate_field` has an optional `return_instead` parameter which accepts
+either a static value or a one-argument callable, when the deprecated field is
+accessed, the value that is returned will depend on the argument passed to the
+`return_instead` parameter.
+
+### Static values
+
+Returning a static value on deprecated field access is pretty simple, all
+you have to do is pass a Python literal, variable, constant, etc. as argument
+to the `return_instead` parameter like so:
+
+```python
+from django.db import models
+from django_deprecate_fields import deprecate_field
+
+class MyModel(models.Model):
+    field1 = deprecate_field(models.CharField(), return_instead="Foo")
+    field2 = models.CharField()
+```
+
+Now every time `MyModel.field1` is accessed `"foo"` will be returned.
+
+### Dynamic values
+
+The `return_instead` parameter also accepts callables with one argument.
+
+This argument will always be the model instance on which the field is being
+accessed, this allows you to use other Model instance attributes to alias
+or even extrapolate the result of accessing the deprecated field.
+
+Here's an example of a simple callable that will return either "foo" or "bar"
+when the deprecated field is accessed, depending on luck:
+
+```python
+import random
+
+from django.db import models
+from django_deprecate_fields import deprecate_field
+
+
+def my_func(_):
+    # note that we don't need to extrapolate the return value based on the
+    # model instance so we simply "discard" it using the _ convention
+    return random.choice(["foo", "bar"])
+
+
+class MyModel(models.Model):
+    field1 = deprecate_field(models.CharField(), return_instead=my_func)
+    field2 = models.CharField()
+```
+
+Here's an example of a callable that uses the Model instance argument which
+will simply alias field1 to field2.
+
+```python
+from django.db import models
+from django_deprecate_fields import deprecate_field
+
+
+def my_func(obj):
+    return obj.field2
+
+
+class MyModel(models.Model):
+    field1 = deprecate_field(models.CharField(), return_instead=my_func)
+    field2 = models.CharField()
+```
+
+You can even use model methods, this is the recommended way to do it or
+"best practice":
+
+```python
+from django.db import models
+from django_deprecate_fields import deprecate_field
+
+
+
+class MyModel(models.Model):
+
+    def my_method(self):
+        return self.field2
+
+    field1 = deprecate_field(models.CharField(), return_instead=my_method)
+    field2 = models.CharField()
+```
+
+These are all very simple examples but you can presumably extrapolate values
+from various different fields, allowing you to refactor old code the way you
+want without breaking API for your clients.
 
 ## Contributing
 

--- a/django_deprecate_fields/deprecate_field.py
+++ b/django_deprecate_fields/deprecate_field.py
@@ -14,6 +14,7 @@ class DeprecatedField(object):
     def __init__(self, val):
         self.val = val
 
+
     def _get_name(self, obj):
         """
         Try to find this field's name in the model class
@@ -34,7 +35,10 @@ class DeprecatedField(object):
             return self
         if not callable(self.val):
             return self.val
-        return self.val()
+        # we pass the Model object instance to the callable in case the
+        # value of the deprecated field can be extrapolated from another
+        # field
+        return self.val(obj)
 
     def __set__(self, obj, val):
         msg = "writing to deprecated field %s.%s" % (

--- a/tests/models.py
+++ b/tests/models.py
@@ -2,5 +2,16 @@ from django_deprecate_fields import deprecate_field
 from django.db import models
 
 
+def calc_baz(_):
+    return "baz"
+
+
 class DeprecationModel(models.Model):
+    def _deprecate_ham(self):
+        return self.eggs
+
     foo = deprecate_field(models.IntegerField())
+    bar = deprecate_field(models.CharField(max_length=30), return_instead="bar")
+    baz = deprecate_field(models.CharField(max_length=30), return_instead=calc_baz)
+    eggs = models.CharField(max_length=30, blank=True)
+    ham = deprecate_field(models.CharField(max_length=30), return_instead=_deprecate_ham)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,8 +4,8 @@ from django_deprecate_fields.deprecate_field import DeprecatedField
 from tests.models import DeprecationModel
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 class TestCore:
-    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     def test_descriptor_access(self):
         """
         Test that accessing a descriptor through Model class works.
@@ -19,3 +19,23 @@ class TestCore:
         """
         assert DeprecationModel().foo is None
         assert isinstance(DeprecationModel.foo, DeprecatedField)
+
+    def test_static_return_instead(self):
+        """
+        Test that a deprecated field with a static return_instead value works.
+        """
+        assert DeprecationModel().bar == "bar"
+
+    def test_function_return_instead(self):
+        """
+        Test that a deprecated field with a function-based return_instead works.
+        """
+        assert DeprecationModel().baz == "baz"
+
+    def test_method_return_instead(self):
+        """
+        Test that a deprecated field with a method-based return_instead works.
+        """
+        dm = DeprecationModel(eggs="eggs")
+        assert dm.ham == "eggs"
+        assert dm.ham == dm.eggs


### PR DESCRIPTION
With this commit, callables passed to return_instead can accept a single argument which will be the model instance on which the deprecated field is being accessed.

This allows users to set the return value of the deprecated field to that of another field directly (aliasing) or to extrapolate what would have been the value based on one or more model instance attributes.

This is a breaking change and any functions/methods passed to return_instead should allow at least one argument.